### PR TITLE
Improve ranking readability for TV display

### DIFF
--- a/ranking-backend/public/index.html
+++ b/ranking-backend/public/index.html
@@ -60,7 +60,7 @@
 
         .container {
             width: 100%;
-            max-width: 1400px;
+            max-width: 1600px;
             margin: 0 auto;
         }
 
@@ -71,7 +71,7 @@
         }
 
         header h1 {
-            font-size: 2.8rem;
+            font-size: 3.2rem;
             font-weight: 700;
             letter-spacing: -1px;
             background: linear-gradient(90deg, var(--accent-primary), var(--accent-secondary));
@@ -111,7 +111,7 @@
 
         .main-content {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
             gap: 30px;
             margin-bottom: 30px;
             margin-top: 20px;
@@ -146,7 +146,7 @@
         .ranking-section h2,
         .top-analysts-panel .panel-title,
         .overall-progress-section h3 {
-            font-size: 1.8rem;
+            font-size: 2.2rem;
             font-weight: 600;
             margin-bottom: 20px;
             border-bottom: 2px solid var(--accent-primary);
@@ -161,7 +161,7 @@
 
         .analyst-cards-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
             gap: 20px;
         }
 
@@ -191,8 +191,8 @@
         }
 
         .analyst-avatar-container {
-            width: 90px;
-            height: 90px;
+            width: 110px;
+            height: 110px;
             border-radius: 50%;
             margin-bottom: 15px;
             display: flex;
@@ -302,7 +302,7 @@
         /* Usando uma cor fixa para bronze */
 
         .analyst-name {
-            font-size: 1.25rem;
+            font-size: 1.4rem;
             font-weight: 600;
             margin-bottom: 5px;
             color: var(--text-primary);
@@ -310,7 +310,7 @@
         }
 
         .team-name {
-            font-size: 0.9rem;
+            font-size: 1rem;
             color: var(--text-secondary);
             margin-bottom: 10px;
             font-style: italic;
@@ -318,7 +318,7 @@
         }
 
         .negotiated-value {
-            font-size: 1.1rem;
+            font-size: 1.3rem;
             font-weight: 500;
             color: var(--accent-secondary);
             transition: color 0.3s ease;
@@ -329,7 +329,7 @@
         }
 
         .analyst-points {
-            font-size: 0.85em;
+            font-size: 0.95em;
             color: var(--accent-primary);
             margin-left: 5px;
             font-weight: 500;
@@ -458,7 +458,7 @@
             align-items: center;
             padding: 12px 0;
             border-bottom: 1px solid var(--card-border);
-            font-size: 0.95rem;
+            font-size: 1.1rem;
             transition: border-color 0.3s ease;
             position: relative;
             /* Para indicadores de movimento na lista */
@@ -535,7 +535,7 @@
             align-items: center;
             justify-content: center;
             font-weight: 600;
-            font-size: 0.9rem;
+            font-size: 1.2rem;
             color: var(--progress-bar-text-color);
             text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
             transition: color 0.3s ease;
@@ -723,7 +723,7 @@
         /* Barra de progresso individual dentro do analyst-card */
         .analyst-card .progress-container {
             width: 100%;
-            height: 6px;
+            height: 8px;
             background-color: rgba(255, 255, 255, 0.15);
             border-radius: 4px;
             margin-top: 12px;
@@ -743,7 +743,7 @@
         .analyst-card .percent-text {
             display: block;
             margin-top: 4px;
-            font-size: 0.75rem;
+            font-size: 1rem;
             font-weight: 500;
             color: var(--text-secondary);
             text-align: right;


### PR DESCRIPTION
## Summary
- enlarge container width for full-screen view
- increase font sizes for titles, cards and progress
- widen grid columns and avatar sizes
- enlarge percentage and list fonts for clarity

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844d15bc1248328a147ac9361fb4be4